### PR TITLE
stop appending UUID to topics by default

### DIFF
--- a/pkg/jetstream/marshaler.go
+++ b/pkg/jetstream/marshaler.go
@@ -28,9 +28,9 @@ type MarshalerUnmarshaler interface {
 	Unmarshaler
 }
 
-func defaultNatsMsg(topic string, uuid string, data []byte, hdr nats.Header) *nats.Msg {
+func defaultNatsMsg(topic string, data []byte, hdr nats.Header) *nats.Msg {
 	return &nats.Msg{
-		Subject: PublishSubject(topic, uuid),
+		Subject: topic,
 		Data:    data,
 		Header:  hdr,
 	}
@@ -48,7 +48,7 @@ func (GobMarshaler) Marshal(topic string, msg *message.Message) (*nats.Msg, erro
 		return nil, errors.Wrap(err, "cannot encode message")
 	}
 
-	return defaultNatsMsg(topic, msg.UUID, buf.Bytes(), nil), nil
+	return defaultNatsMsg(topic, buf.Bytes(), nil), nil
 }
 
 // Unmarshal extracts a watermill message from a nats message.
@@ -84,7 +84,7 @@ func (JSONMarshaler) Marshal(topic string, msg *message.Message) (*nats.Msg, err
 		return nil, errors.Wrap(err, "cannot encode message")
 	}
 
-	return defaultNatsMsg(topic, msg.UUID, bytes, nil), nil
+	return defaultNatsMsg(topic, bytes, nil), nil
 }
 
 // Unmarshal extracts a watermill message from a nats message.
@@ -120,9 +120,8 @@ func (*NATSMarshaler) Marshal(topic string, msg *message.Message) (*nats.Msg, er
 	}
 
 	data := msg.Payload
-	id := msg.UUID
 
-	return defaultNatsMsg(topic, id, data, header), nil
+	return defaultNatsMsg(topic, data, header), nil
 }
 
 // Unmarshal extracts a watermill message from a nats message.

--- a/pkg/jetstream/topic.go
+++ b/pkg/jetstream/topic.go
@@ -1,8 +1,6 @@
 package jetstream
 
 import (
-	"fmt"
-
 	"github.com/nats-io/nats.go"
 )
 
@@ -27,7 +25,7 @@ type topicInterpreter struct {
 
 func defaultSubjectCalculator(topic string) *Subjects {
 	return &Subjects{
-		Primary: fmt.Sprintf("%s.*", topic),
+		Primary: topic,
 	}
 }
 
@@ -58,8 +56,4 @@ func (b *topicInterpreter) ensureStream(topic string) error {
 	}
 
 	return err
-}
-
-func PublishSubject(topic string, uuid string) string {
-	return fmt.Sprintf("%s.%s", topic, uuid)
 }

--- a/pkg/jetstream/wmpb/natsmarshaler.go
+++ b/pkg/jetstream/wmpb/natsmarshaler.go
@@ -1,7 +1,6 @@
 package wmpb
 
 import (
-	"github.com/ThreeDotsLabs/watermill-jetstream/pkg/jetstream"
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/nats-io/nats.go"
 	"google.golang.org/protobuf/proto"
@@ -22,7 +21,7 @@ func (*NATSMarshaler) Marshal(topic string, msg *message.Message) (*nats.Msg, er
 		return nil, err
 	}
 
-	natsMsg := nats.NewMsg(jetstream.PublishSubject(topic, msg.UUID))
+	natsMsg := nats.NewMsg(topic)
 	natsMsg.Data = data
 
 	return natsMsg, nil


### PR DESCRIPTION
This was a holdover from the old nats-streaming implementation if I remember right and isn't really necessary.  It kind of forces a pattern on non-watermill publishers as well.  If this behavior is missed it could be reintroduced with an alternate subject calculator pretty easily.