### PR TITLE
feat: add NakWithDelay

### DIFF
--- a/pkg/jetstream/delay.go
+++ b/pkg/jetstream/delay.go
@@ -1,0 +1,28 @@
+package jetstream
+
+import (
+	"time"
+)
+
+// StopTime if this duration was returned, event will be term`ed
+const StopTime = time.Duration(-1)
+
+type Delay interface {
+	// WaitTime return time.Duration that we need to wait.
+	// retryNum is how many times WaitTime was called for
+	// specific message
+	WaitTime(retryNum uint64) time.Duration
+}
+
+// StaticDelay delay that always return the same time.Duration
+type StaticDelay struct {
+	Delay time.Duration
+}
+
+func NewStaticDelay(delay time.Duration) StaticDelay {
+	return StaticDelay{Delay: delay}
+}
+
+func (s StaticDelay) WaitTime(retryNum int) time.Duration {
+	return s.Delay
+}


### PR DESCRIPTION
For now if an error is returned from the handler, the message will be nacked. NATS JetStream, in turn, will try to send it back as soon as it receives a nack (if MaxDeliver > 1).

> You can also control the timing of re-deliveries when messages are negatively acknowledged with Nak(), by passing a nakDelay() option (or using NakWithDelay()), **otherwise the re-delivery attempt will happen right after the reception of the Nak by the server.**
> 
> cc: [NATS docs](https://docs.nats.io/using-nats/developer/develop_jetstream/consumers#message-re-deliveries)

For me, this is not quite the behavior that I would like to see. I would like the message to be sent again after some time.

To do this, the `NakWithDelay` function was added to NATS. In this PR, i have added an option to SubscriberConfig to control the delay of nacked messages.