### PR TITLE
Fix deleting durable subscriptions on unsubscribe

### DIFF
--- a/pkg/jetstream/publisher.go
+++ b/pkg/jetstream/publisher.go
@@ -42,6 +42,12 @@ type PublisherPublishConfig struct {
 	// SubjectCalculator is a function used to transform a topic to an array of subjects on creation (defaults to "{topic}.*")
 	SubjectCalculator SubjectCalculator
 
+	// DurableNameCalculator is a function used to calculate nats durable names for the given topic.
+	DurableNameCalculator DurableNameCalculator
+
+	// QueueGroupCalculator is a function used to calculate nats queue group for the given topic.
+	QueueGroupCalculator QueueGroupCalculator
+
 	// AutoProvision bypasses client validation and provisioning of streams
 	AutoProvision bool
 
@@ -123,11 +129,16 @@ func NewPublisherWithNatsConn(conn *nats.Conn, config PublisherPublishConfig, lo
 	}
 
 	return &Publisher{
-		conn:             conn,
-		config:           config,
-		logger:           logger,
-		js:               js,
-		topicInterpreter: newTopicInterpreter(js, config.SubjectCalculator),
+		conn:   conn,
+		config: config,
+		logger: logger,
+		js:     js,
+		topicInterpreter: newTopicInterpreter(
+			js,
+			config.SubjectCalculator,
+			config.DurableNameCalculator,
+			config.QueueGroupCalculator,
+		),
 	}, nil
 }
 

--- a/pkg/jetstream/publisher.go
+++ b/pkg/jetstream/publisher.go
@@ -42,10 +42,10 @@ type PublisherPublishConfig struct {
 	// SubjectCalculator is a function used to transform a topic to an array of subjects on creation (defaults to "{topic}.*")
 	SubjectCalculator SubjectCalculator
 
-	// DurableNameCalculator is a function used to calculate nats durable names for the given topic.
+	// DurableNameCalculator is a function used to calculate nats durable names for the given topic (defaults to DurableName)
 	DurableNameCalculator DurableNameCalculator
 
-	// QueueGroupCalculator is a function used to calculate nats queue group for the given topic.
+	// QueueGroupCalculator is a function used to calculate nats queue group for the given topic (defaults to QueueGroup)
 	QueueGroupCalculator QueueGroupCalculator
 
 	// AutoProvision bypasses client validation and provisioning of streams

--- a/pkg/jetstream/publisher.go
+++ b/pkg/jetstream/publisher.go
@@ -24,12 +24,6 @@ type PublisherConfig struct {
 	// SubjectCalculator is a function used to transform a topic to an array of subjects on creation (defaults to "{topic}.*")
 	SubjectCalculator SubjectCalculator
 
-	// DurableNameCalculator is a function used to calculate nats durable names for the given topic (defaults to DurableName)
-	DurableNameCalculator DurableNameCalculator
-
-	// QueueGroupCalculator is a function used to calculate nats queue group for the given topic (defaults to QueueGroup)
-	QueueGroupCalculator QueueGroupCalculator
-
 	// AutoProvision bypasses client validation and provisioning of streams
 	AutoProvision bool
 
@@ -47,12 +41,6 @@ type PublisherPublishConfig struct {
 
 	// SubjectCalculator is a function used to transform a topic to an array of subjects on creation (defaults to "{topic}.*")
 	SubjectCalculator SubjectCalculator
-
-	// DurableNameCalculator is a function used to calculate nats durable names for the given topic (defaults to DurableName)
-	DurableNameCalculator DurableNameCalculator
-
-	// QueueGroupCalculator is a function used to calculate nats queue group for the given topic (defaults to QueueGroup)
-	QueueGroupCalculator QueueGroupCalculator
 
 	// AutoProvision bypasses client validation and provisioning of streams
 	AutoProvision bool
@@ -88,14 +76,12 @@ func (c PublisherConfig) Validate() error {
 // GetPublisherPublishConfig gets the configuration subset needed for individual publish calls once a connection has been established
 func (c PublisherConfig) GetPublisherPublishConfig() PublisherPublishConfig {
 	return PublisherPublishConfig{
-		Marshaler:             c.Marshaler,
-		SubjectCalculator:     c.SubjectCalculator,
-		AutoProvision:         c.AutoProvision,
-		JetstreamOptions:      c.JetstreamOptions,
-		PublishOptions:        c.PublishOptions,
-		DurableNameCalculator: c.DurableNameCalculator,
-		QueueGroupCalculator:  c.QueueGroupCalculator,
-		TrackMsgId:            c.TrackMsgId,
+		Marshaler:         c.Marshaler,
+		SubjectCalculator: c.SubjectCalculator,
+		AutoProvision:     c.AutoProvision,
+		JetstreamOptions:  c.JetstreamOptions,
+		PublishOptions:    c.PublishOptions,
+		TrackMsgId:        c.TrackMsgId,
 	}
 }
 
@@ -144,8 +130,7 @@ func NewPublisherWithNatsConn(conn *nats.Conn, config PublisherPublishConfig, lo
 		topicInterpreter: newTopicInterpreter(
 			js,
 			config.SubjectCalculator,
-			config.DurableNameCalculator,
-			config.QueueGroupCalculator,
+			nil, nil,
 		),
 	}, nil
 }

--- a/pkg/jetstream/publisher.go
+++ b/pkg/jetstream/publisher.go
@@ -24,6 +24,12 @@ type PublisherConfig struct {
 	// SubjectCalculator is a function used to transform a topic to an array of subjects on creation (defaults to "{topic}.*")
 	SubjectCalculator SubjectCalculator
 
+	// DurableNameCalculator is a function used to calculate nats durable names for the given topic (defaults to DurableName)
+	DurableNameCalculator DurableNameCalculator
+
+	// QueueGroupCalculator is a function used to calculate nats queue group for the given topic (defaults to QueueGroup)
+	QueueGroupCalculator QueueGroupCalculator
+
 	// AutoProvision bypasses client validation and provisioning of streams
 	AutoProvision bool
 
@@ -82,12 +88,14 @@ func (c PublisherConfig) Validate() error {
 // GetPublisherPublishConfig gets the configuration subset needed for individual publish calls once a connection has been established
 func (c PublisherConfig) GetPublisherPublishConfig() PublisherPublishConfig {
 	return PublisherPublishConfig{
-		Marshaler:         c.Marshaler,
-		SubjectCalculator: c.SubjectCalculator,
-		AutoProvision:     c.AutoProvision,
-		JetstreamOptions:  c.JetstreamOptions,
-		PublishOptions:    c.PublishOptions,
-		TrackMsgId:        c.TrackMsgId,
+		Marshaler:             c.Marshaler,
+		SubjectCalculator:     c.SubjectCalculator,
+		AutoProvision:         c.AutoProvision,
+		JetstreamOptions:      c.JetstreamOptions,
+		PublishOptions:        c.PublishOptions,
+		DurableNameCalculator: c.DurableNameCalculator,
+		QueueGroupCalculator:  c.QueueGroupCalculator,
+		TrackMsgId:            c.TrackMsgId,
 	}
 }
 

--- a/pkg/jetstream/subscriber.go
+++ b/pkg/jetstream/subscriber.go
@@ -74,6 +74,12 @@ type SubscriberConfig struct {
 	// SubjectCalculator is a function used to transform a topic to an array of subjects on creation (defaults to "{topic}.*")
 	SubjectCalculator SubjectCalculator
 
+	// DurableNameCalculator is a function used to calculate nats durable names for the given topic (defaults to DurableName)
+	DurableNameCalculator DurableNameCalculator
+
+	// QueueGroupCalculator is a function used to calculate nats queue group for the given topic (defaults to QueueGroup)
+	QueueGroupCalculator QueueGroupCalculator
+
 	// AutoProvision bypasses client validation and provisioning of streams
 	AutoProvision bool
 
@@ -150,18 +156,20 @@ type SubscriberSubscriptionConfig struct {
 // GetSubscriberSubscriptionConfig gets the configuration subset needed for individual subscribe calls once a connection has been established
 func (c *SubscriberConfig) GetSubscriberSubscriptionConfig() SubscriberSubscriptionConfig {
 	return SubscriberSubscriptionConfig{
-		Unmarshaler:       c.Unmarshaler,
-		QueueGroup:        c.QueueGroup,
-		DurableName:       c.DurableName,
-		SubscribersCount:  c.SubscribersCount,
-		AckWaitTimeout:    c.AckWaitTimeout,
-		CloseTimeout:      c.CloseTimeout,
-		SubscribeTimeout:  c.SubscribeTimeout,
-		SubscribeOptions:  c.SubscribeOptions,
-		SubjectCalculator: c.SubjectCalculator,
-		AutoProvision:     c.AutoProvision,
-		JetstreamOptions:  c.JetstreamOptions,
-		AckSync:           c.AckSync,
+		Unmarshaler:           c.Unmarshaler,
+		QueueGroup:            c.QueueGroup,
+		DurableName:           c.DurableName,
+		SubscribersCount:      c.SubscribersCount,
+		AckWaitTimeout:        c.AckWaitTimeout,
+		CloseTimeout:          c.CloseTimeout,
+		SubscribeTimeout:      c.SubscribeTimeout,
+		SubscribeOptions:      c.SubscribeOptions,
+		SubjectCalculator:     c.SubjectCalculator,
+		DurableNameCalculator: c.DurableNameCalculator,
+		QueueGroupCalculator:  c.QueueGroupCalculator,
+		AutoProvision:         c.AutoProvision,
+		JetstreamOptions:      c.JetstreamOptions,
+		AckSync:               c.AckSync,
 	}
 }
 

--- a/pkg/jetstream/subscriber.go
+++ b/pkg/jetstream/subscriber.go
@@ -134,10 +134,10 @@ type SubscriberSubscriptionConfig struct {
 	// SubjectCalculator is a function used to transform a topic to an array of subjects on creation (defaults to "{topic}.*")
 	SubjectCalculator SubjectCalculator
 
-	// DurableNameCalculator is a function used to calculate nats durable names for the given topic.
+	// DurableNameCalculator is a function used to calculate nats durable names for the given topic (defaults to DurableName)
 	DurableNameCalculator DurableNameCalculator
 
-	// QueueGroupCalculator is a function used to calculate nats queue group for the given topic.
+	// QueueGroupCalculator is a function used to calculate nats queue group for the given topic (defaults to QueueGroup)
 	QueueGroupCalculator QueueGroupCalculator
 
 	// AutoProvision bypasses client validation and provisioning of streams


### PR DESCRIPTION
When the application wants to stop receiving messages on a durable subscription, it should close - but not unsubscribe - this subscription.

https://docs.nats.io/legacy/stan/intro/channels/subscriptions/durable